### PR TITLE
Make Port in config.json a Number

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,8 +1,8 @@
 {
-	"token":"YOUR_BOT_TOKEN_HERE",
+    "token":"YOUR_BOT_TOKEN_HERE",
     "commandPrefix":"/",
     "ip":"YOUR_SERVER_IP_HERE",
-    "port":"25565",
+    "port":25565,
     "pingInterval":"30",
     "embedColor":"7289DA"
 }


### PR DESCRIPTION
The port in the config by default has to be a number, because mc-ping-status expects a number, otherwise it uses the default port instead of the desired port.
Fixes #23 