### PR TITLE
Nicknames

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ A simple [Discord.js](https://www.npmjs.com/package/discord.js) bot that display
 ## To-Do
 
 - [ ] Allow users to manage default server for `/status` command (`/default ip` command and `/monitor ip [default]` option, add new key-value pair to server object and use findIndex to get default server)
-- [ ] Allow users to set a nickname for the server (`/nickname` and `/monitor ip nickname`)
+- [x] Allow users to set a nickname for the server (`/nickname` and `/monitor ip nickname`)
 - [ ] Rework admin permissions
-- [ ] Rework status and unmonitor commands to include dropdown menus
-- [ ] Rework monitor command to include modal workflow
+- [ ] Rework status, nickname, and unmonitor commands to include dropdown menus
+- [ ] Rework monitor and nickname commands to include modal workflow
 - [ ] Add graph support (see [this](https://github.com/cappig/MC-status-bot) repository)
 - [ ] Update readme with screenshots
 - [ ] Rectify backend caching

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ A simple [Discord.js](https://www.npmjs.com/package/discord.js) bot that display
 
 ## Usage
 
+- `/status [server|ip]` - Displays the current status and active players for any server
+- `/monitor ip [nickname]` - Create 2 voice channels that display the status of a Minecraft server and optionally set a nickname
+- `/nickname [server] nickname` - Change the nickname of a monitored Minecraft server
+- `/unmonitor [server|all]` - Unmonitor the specified server or all servers
+- `/bug description` - Send a bug report to the maintainers
 - `/help` - List the other commands
-- `/status ip?` - Displays the current status and active players for the default server (the first server that was monitored that hasn't been unmonitored) or the specified IP address if provided
-- `/monitor ip` - Monitor the server with the specified IP address
-- `/unmonitor ip|all` - Unmonitor the server with the specified IP address or all servers
-- `/bug desc` - Send a bug report to the maintainers
 
 ## To-Do
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,10 @@ A simple [Discord.js](https://www.npmjs.com/package/discord.js) bot that display
 
 **To use:** Simply [invite](https://discord.com/api/oauth2/authorize?client_id=788083161296273517&permissions=268435472&scope=bot%20applications.commands) the bot to your server
 
-## Now Updated!!
+## Now Updated!
 
 - Updated Jan 2023
-- New hosting provider
-- Bot will be hosted centrally from now on
-- Fixing bugs from now till Feb and then focusing on new features
+- Nicknames have been implemented! Set a nickname for your server with the `/nickname` command. You can refer to the server using its nickname in all commands!
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,12 @@ A simple [Discord.js](https://www.npmjs.com/package/discord.js) bot that display
 ## To-Do
 
 - [ ] Allow users to manage default server for `/status` command (`/default ip` command and `/monitor ip [default]` option, add new key-value pair to server object and use findIndex to get default server)
-- [ ] Allow users to set a nickname for the server (`/nickname` command and `/monitor ip nickname`)
+- [ ] Allow users to set a nickname for the server (`/nickname` and `/monitor ip nickname`)
+- [ ] Rework admin permissions
+- [ ] Rework status and unmonitor commands to include dropdown menus
+- [ ] Rework monitor command to include modal workflow
 - [ ] Add graph support (see [this](https://github.com/cappig/MC-status-bot) repository)
+- [ ] Update readme with screenshots
 - [ ] Rectify backend caching
 - [ ] Fix DDNS support issues
 - [x] Add bug reporting command

--- a/commands/bug.js
+++ b/commands/bug.js
@@ -6,7 +6,7 @@ var profanity = require('@2toad/profanity').profanity;
 module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('bug')
-		.setDescription('Send bug report to maintainers')
+		.setDescription('Send a bug report to maintainers')
 		.addStringOption((option) => option.setName('bug').setDescription('Description of the bug').setRequired(true)),
 	async execute(interaction) {
 		await interaction.deferReply({ ephemeral: true });

--- a/commands/help.js
+++ b/commands/help.js
@@ -12,14 +12,17 @@ module.exports = {
 				value: 'Displays the current status and active players for your server'
 			},
 			{
-				name: '/monitor ip',
-				value: 'Monitor the server with the specified IP address'
+				name: '/monitor ip [nickname]',
+				value: 'Monitor the server with the specified IP address and optionally set a nickname'
 			},
 			{
-				name: '/unmonitor ip|all',
+				name: '/unmonitor [ip|all]',
 				value: 'Unmonitor the server with the specified IP address or all servers'
 			},
-			{ name: '/bug desc', value: 'Send a bug to maintainers ' }
+			{
+				name: '/bug description',
+				value: 'Send a bug report to the maintainers'
+			}
 		);
 		await interaction.editReply({ embeds: [helpEmbed], ephemeral: true });
 	}

--- a/commands/help.js
+++ b/commands/help.js
@@ -9,19 +9,19 @@ module.exports = {
 		const helpEmbed = new Discord.EmbedBuilder().setTitle('Commands:').setColor(embedColor).addFields(
 			{
 				name: '/status [server|ip]',
-				value: 'Displays the current status and active players for your server'
+				value: 'Displays the current status and active players for any server'
 			},
 			{
 				name: '/monitor ip [nickname]',
-				value: 'Monitor the server with the specified IP address and optionally set a nickname'
+				value: 'Create 2 voice channels that display the status of a Minecraft server and optionally set a nickname'
 			},
 			{
 				name: '/nickname [server] nickname',
-				value: 'Change the display name of a monitored Minecraft server'
+				value: 'Change the nickname of a monitored Minecraft server'
 			},
 			{
 				name: '/unmonitor [server|all]',
-				value: 'Unmonitor the server with the specified IP address or all servers'
+				value: 'Unmonitor the specified server or all servers'
 			},
 			{
 				name: '/bug description',

--- a/commands/help.js
+++ b/commands/help.js
@@ -8,7 +8,7 @@ module.exports = {
 
 		const helpEmbed = new Discord.EmbedBuilder().setTitle('Commands:').setColor(embedColor).addFields(
 			{
-				name: '/status [ip]',
+				name: '/status [server|ip]',
 				value: 'Displays the current status and active players for your server'
 			},
 			{
@@ -16,7 +16,11 @@ module.exports = {
 				value: 'Monitor the server with the specified IP address and optionally set a nickname'
 			},
 			{
-				name: '/unmonitor [ip|all]',
+				name: '/nickname [server] nickname',
+				value: 'Change the display name of a monitored Minecraft server'
+			},
+			{
+				name: '/unmonitor [server|all]',
 				value: 'Unmonitor the server with the specified IP address or all servers'
 			},
 			{

--- a/commands/monitor.js
+++ b/commands/monitor.js
@@ -7,7 +7,8 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('monitor')
 		.setDescription('Create a channel category and 2 voice channels that display the status of a Minecraft server')
-		.addStringOption((option) => option.setName('ip').setDescription('IP address').setRequired(true)),
+		.addStringOption((option) => option.setName('ip').setDescription('IP address').setRequired(true))
+		.addStringOption((option) => option.setName('nickname').setDescription('Server nickname').setRequired(false)),
 	async execute(interaction) {
 		await interaction.deferReply({ ephemeral: true });
 
@@ -17,18 +18,37 @@ module.exports = {
 			return;
 		}
 
-		let newServer = {
-			ip: interaction.options.getString('ip')
-		};
-
-		// Create the server category
+		// Check if the bot has the manage roles permission
 		if (!interaction.guild.roles.botRoleFor(interaction.client.user).permissions.has(Discord.PermissionsBitField.Flags.ManageRoles)) {
 			await sendMessage.newBasicMessage(interaction, 'This bot needs the "manage roles" permission in order to create channels!');
 			return;
 		}
+
+		// Check if the server is already being monitored
+		let monitoredServers = (await serverDB.get(interaction.guildId)) || [];
+		let serverIndex = monitoredServers.findIndex((server) => server.ip == interaction.options.getString('ip'));
+		if (serverIndex != -1) {
+			await sendMessage.newBasicMessage(interaction, 'This server is already being monitored!');
+			return;
+		}
+
+		// Check if the nickname is already being used
+		nicknameIndex = monitoredServers.findIndex((server) => server.nickname == interaction.options.getString('nickname'));
+		if (interaction.options.getString('nickname') && nicknameIndex != -1) {
+			await sendMessage.newBasicMessage(interaction, 'This nickname is already being used!');
+			return;
+		}
+
+		// Create the server object
+		let newServer = {
+			ip: interaction.options.getString('ip'),
+			nickname: interaction.options.getString('nickname') || null
+		};
+
+		// Create the server category
 		await interaction.guild.channels
 			.create({
-				name: interaction.options.getString('ip'),
+				name: interaction.options.getString('nickname') || interaction.options.getString('ip'),
 				type: Discord.ChannelType.GuildCategory,
 				permissionOverwrites: [
 					{
@@ -45,7 +65,7 @@ module.exports = {
 				newServer.categoryId = channel.id;
 			});
 
-		// Crate channels and add to category
+		// Create the channels and add to category
 		await interaction.guild.channels
 			.create({
 				name: 'Status: Updating...',
@@ -66,7 +86,6 @@ module.exports = {
 				newServer.playersId = channel.id;
 			});
 
-		let monitoredServers = (await serverDB.get(interaction.guildId)) || [];
 		monitoredServers.push(newServer);
 		await serverDB.set(interaction.guildId, monitoredServers);
 

--- a/commands/monitor.js
+++ b/commands/monitor.js
@@ -26,14 +26,14 @@ module.exports = {
 
 		// Check if the server is already being monitored
 		let monitoredServers = (await serverDB.get(interaction.guildId)) || [];
-		let serverIndex = monitoredServers.findIndex((server) => server.ip == interaction.options.getString('ip'));
+		let serverIndex = await monitoredServers.findIndex((server) => server.ip == interaction.options.getString('ip'));
 		if (serverIndex != -1) {
 			await sendMessage.newBasicMessage(interaction, 'This server is already being monitored!');
 			return;
 		}
 
 		// Check if the nickname is already being used
-		nicknameIndex = monitoredServers.findIndex((server) => server.nickname == interaction.options.getString('nickname'));
+		nicknameIndex = await monitoredServers.findIndex((server) => server.nickname == interaction.options.getString('nickname'));
 		if (interaction.options.getString('nickname') && nicknameIndex != -1) {
 			await sendMessage.newBasicMessage(interaction, 'This nickname is already being used!');
 			return;
@@ -86,10 +86,10 @@ module.exports = {
 				newServer.playersId = channel.id;
 			});
 
-		monitoredServers.push(newServer);
+		await monitoredServers.push(newServer);
 		await serverDB.set(interaction.guildId, monitoredServers);
 
-		updateChannels.execute(newServer);
+		await updateChannels.execute(newServer);
 
 		await sendMessage.newBasicMessage(interaction, 'The channels have been created successfully.');
 	}

--- a/commands/monitor.js
+++ b/commands/monitor.js
@@ -6,7 +6,7 @@ const sendMessage = require('../functions/sendMessage');
 module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('monitor')
-		.setDescription('Create a channel category and 2 voice channels that display the status of a Minecraft server')
+		.setDescription('Create 2 voice channels that display the status of a Minecraft server')
 		.addStringOption((option) => option.setName('ip').setDescription('IP address').setRequired(true))
 		.addStringOption((option) => option.setName('nickname').setDescription('Server nickname').setRequired(false)),
 	async execute(interaction) {

--- a/commands/nickname.js
+++ b/commands/nickname.js
@@ -5,7 +5,7 @@ const sendMessage = require('../functions/sendMessage');
 module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('nickname')
-		.setDescription('Change the display name of a monitored Minecraft server')
+		.setDescription('Change the nickname of a monitored Minecraft server')
 		.addStringOption((option) => option.setName('server').setDescription('Server IP address or nickname').setRequired(true))
 		.addStringOption((option) => option.setName('nickname').setDescription('Server nickname').setRequired(true)),
 	async execute(interaction) {

--- a/commands/nickname.js
+++ b/commands/nickname.js
@@ -1,0 +1,63 @@
+const Discord = require('discord.js');
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const sendMessage = require('../functions/sendMessage');
+
+module.exports = {
+	data: new SlashCommandBuilder()
+		.setName('nickname')
+		.setDescription('Change the display name of a monitored Minecraft server')
+		.addStringOption((option) => option.setName('server').setDescription('Server IP address or nickname').setRequired(true))
+		.addStringOption((option) => option.setName('nickname').setDescription('Server nickname').setRequired(true)),
+	async execute(interaction) {
+		await interaction.deferReply({ ephemeral: true });
+
+		// Check if the member has the administrator permission
+		if (!interaction.memberPermissions.has(Discord.PermissionsBitField.Flags.Administrator)) {
+			await sendMessage.newBasicMessage(interaction, 'You must have the administrator permission to use this command!');
+			return;
+		}
+
+		// Check if the bot has the manage roles permission
+		if (!interaction.guild.roles.botRoleFor(interaction.client.user).permissions.has(Discord.PermissionsBitField.Flags.ManageRoles)) {
+			await sendMessage.newBasicMessage(interaction, 'This bot needs the "manage roles" permission in order to rename channels!');
+			return;
+		}
+
+        // Check if there are any servers to rename
+		const monitoredServers = (await serverDB.get(interaction.guildId)) || [];
+		if (!monitoredServers.length) {
+			await sendMessage.newBasicMessage(interaction, 'There are no servers to rename!');
+			return;
+		}
+
+		// Check if the nickname is already being used
+		nicknameIndex = await monitoredServers.findIndex((server) => server.nickname == interaction.options.getString('nickname'));
+		if (interaction.options.getString('nickname') && nicknameIndex != -1) {
+			await sendMessage.newBasicMessage(interaction, 'This nickname is already being used!');
+			return;
+		}
+
+		// Find the server to rename
+		let server = monitoredServers.length == 1 ? monitoredServers[0] : null;
+		if (interaction.options.getString('server')) {
+			let serverIndex = await monitoredServers.findIndex((server) => server.nickname == interaction.options.getString('server'));
+			serverIndex == -1 ? serverIndex = await monitoredServers.findIndex((server) => server.ip == interaction.options.getString('server')) : null;
+			server = serverIndex != -1 ? monitoredServers[serverIndex] : null;
+		}
+
+		// Check if the server is being monitored
+		if (!server) {
+			await sendMessage.newBasicMessage(interaction, 'The server you have specified was not already being monitored!')
+			return;
+		}
+
+		// Rename the server
+        server.nickname = interaction.options.getString('nickname');
+        await serverDB.set(interaction.guildId, monitoredServers);
+
+        // Rename the server category
+        await interaction.guild.channels.cache.get(server.categoryId).setName(interaction.options.getString('nickname'));
+
+		await sendMessage.newBasicMessage(interaction, 'The server has been renamed successfully.');
+	}
+};

--- a/commands/status.js
+++ b/commands/status.js
@@ -7,23 +7,27 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('status')
 		.setDescription('Displays the current status and active players for your server')
-		.addStringOption((option) => option.setName('ip').setDescription('IP Address').setRequired(false)),
+		.addStringOption((option) => option.setName('server').setDescription('Server IP address or nickname').setRequired(false)),
 	async execute(interaction) {
 		await interaction.deferReply({ ephemeral: true });
 
 		const monitoredServers = (await serverDB.get(interaction.guildId)) || [];
-		defaultIp = monitoredServers[0].ip || null;
-		ipFull = interaction.options.getString('ip') || defaultIp;
-		if (!ipFull) {
+		let serverIp = monitoredServers.length == 1 ? monitoredServers[0].ip : null;
+		if(interaction.options.getString('server')) {
+			serverIndex = monitoredServers.findIndex((server) => server.nickname == interaction.options.getString('server'));
+			serverIp = serverIndex == -1 ? interaction.options.getString('server') : monitoredServers[serverIndex].ip;
+		}
+		if (!serverIp) {
 			await sendMessage.newBasicMessage(interaction, 'You must monitor a server or specify an IP address to use this command!');
 			return;
 		}
-		ip = ipFull.split(':')[0];
-		port = ipFull.split(':')[1] || 25565;
+
+		ip = serverIp.split(':')[0];
+		port = serverIp.split(':')[1] || 25565;
 		const server = new mcping.MinecraftServer(ip, port);
 		server.ping(2500, 47, async function (err, res) {
 			if (err) {
-				await sendMessage.newMessageWithTitle(interaction, `*The server is offline!*`, `Status for ${ipFull}:`);
+				await sendMessage.newMessageWithTitle(interaction, `*The server is offline!*`, `Status for ${serverIp}:`);
 				return;
 			} else {
 				if (!res.players.sample) {
@@ -40,7 +44,7 @@ module.exports = {
 					serverStatus = `**${res.players.online || 0}/${res.players.max}** player(s) online.\n\n${onlinePlayers}`;
 				}
 				const responseEmbed = new Discord.EmbedBuilder()
-					.setTitle(`Status for ${ipFull}:`)
+					.setTitle(`Status for ${serverIp}:`)
 					.setColor(embedColor)
 					.setDescription(serverStatus)
 					.addFields({ name: 'Server version:', value: res.version.name })

--- a/commands/status.js
+++ b/commands/status.js
@@ -14,7 +14,7 @@ module.exports = {
 		const monitoredServers = (await serverDB.get(interaction.guildId)) || [];
 		let serverIp = monitoredServers.length == 1 ? monitoredServers[0].ip : null;
 		if(interaction.options.getString('server')) {
-			serverIndex = monitoredServers.findIndex((server) => server.nickname == interaction.options.getString('server'));
+			serverIndex = await monitoredServers.findIndex((server) => server.nickname == interaction.options.getString('server'));
 			serverIp = serverIndex == -1 ? interaction.options.getString('server') : monitoredServers[serverIndex].ip;
 		}
 		if (!serverIp) {
@@ -49,7 +49,7 @@ module.exports = {
 					.setDescription(serverStatus)
 					.addFields({ name: 'Server version:', value: res.version.name })
 					.setThumbnail(`https://api.mcsrvstat.us/icon/${ip}:${port}`);
-				interaction.editReply({ embeds: [responseEmbed], ephemeral: true });
+				await interaction.editReply({ embeds: [responseEmbed], ephemeral: true });
 			}
 		});
 	}

--- a/commands/status.js
+++ b/commands/status.js
@@ -6,7 +6,7 @@ const sendMessage = require('../functions/sendMessage');
 module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('status')
-		.setDescription('Displays the current status and active players for your server')
+		.setDescription('Displays the current status and active players for any server')
 		.addStringOption((option) => option.setName('server').setDescription('Server IP address or nickname').setRequired(false)),
 	async execute(interaction) {
 		await interaction.deferReply({ ephemeral: true });

--- a/commands/unmonitor.js
+++ b/commands/unmonitor.js
@@ -7,7 +7,7 @@ module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('unmonitor')
 		.setDescription('Remove a Minecraft server from the monitor list')
-		.addStringOption((option) => option.setName('ip').setDescription('IP address').setRequired(true)),
+		.addStringOption((option) => option.setName('server').setDescription('Server IP address or nickname').setRequired(false)),
 	async execute(interaction) {
 		await interaction.deferReply({ ephemeral: true });
 
@@ -17,21 +17,44 @@ module.exports = {
 			return;
 		}
 
-		// Get server from database
-		let monitoredServers = (await serverDB.get(interaction.guildId)) || [];
-		if (interaction.options.getString('ip') == 'all') {
+		// Check if there are any servers to unmonitor
+		const monitoredServers = (await serverDB.get(interaction.guildId)) || [];
+		if (!monitoredServers.length) {
+			await sendMessage.newBasicMessage(interaction, 'There are no servers to unmonitor!');
+			return;
+		}
+
+		// Check if there are multiple servers to unmonitor and none were specified
+		if (!interaction.options.getString('server') && monitoredServers.length > 1) {
+			await sendMessage.newBasicMessage(interaction, 'Please specify a server to unmonitor!');
+			return;
+		}
+
+		// Unmonitor all servers if specified
+		if (interaction.options.getString('server') == 'all') {
 			for (const server of monitoredServers) {
 				await removeServer.execute(interaction.guild, server);
 			}
-		} else {
-			const serverIndex = monitoredServers ? monitoredServers.findIndex((server) => server.ip == interaction.options.getString('ip')) : -1;
-			if (serverIndex == -1) {
-				await sendMessage.newBasicMessage(interaction, 'The IP address you have specified was not already being monitored.');
-				return;
-			}
-			server = monitoredServers[serverIndex];
-			removeServer.execute(interaction.guild, server);
+			await sendMessage.newBasicMessage(interaction, 'The channels have been removed successfully.');
+			return;
 		}
+
+		// Find the server to unmonitor
+		let server = monitoredServers.length == 1 ? monitoredServers[0] : null;
+		if (interaction.options.getString('server')) {
+			let serverIndex = monitoredServers.findIndex((server) => server.nickname == interaction.options.getString('server'));
+			serverIndex == -1 ? serverIndex = monitoredServers.findIndex((server) => server.ip == interaction.options.getString('server')) : null;
+			server = serverIndex != -1 ? monitoredServers[serverIndex] : null;
+		}
+
+		// Check if the server is being monitored
+		if (!server) {
+			await sendMessage.newBasicMessage(interaction, 'The server you have specified was not already being monitored!')
+			return;
+		}
+		
+		// Unmonitor the server
+		removeServer.execute(interaction.guild, server);
 
 		await sendMessage.newBasicMessage(interaction, 'The channels have been removed successfully.');
 	}

--- a/commands/unmonitor.js
+++ b/commands/unmonitor.js
@@ -6,7 +6,7 @@ const sendMessage = require('../functions/sendMessage');
 module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('unmonitor')
-		.setDescription('Remove a Minecraft server from the monitor list')
+		.setDescription('Unmonitor the specified server or all servers')
 		.addStringOption((option) => option.setName('server').setDescription('Server IP address or nickname').setRequired(false)),
 	async execute(interaction) {
 		await interaction.deferReply({ ephemeral: true });

--- a/commands/unmonitor.js
+++ b/commands/unmonitor.js
@@ -42,8 +42,8 @@ module.exports = {
 		// Find the server to unmonitor
 		let server = monitoredServers.length == 1 ? monitoredServers[0] : null;
 		if (interaction.options.getString('server')) {
-			let serverIndex = monitoredServers.findIndex((server) => server.nickname == interaction.options.getString('server'));
-			serverIndex == -1 ? serverIndex = monitoredServers.findIndex((server) => server.ip == interaction.options.getString('server')) : null;
+			let serverIndex = await monitoredServers.findIndex((server) => server.nickname == interaction.options.getString('server'));
+			serverIndex == -1 ? serverIndex = await monitoredServers.findIndex((server) => server.ip == interaction.options.getString('server')) : null;
 			server = serverIndex != -1 ? monitoredServers[serverIndex] : null;
 		}
 
@@ -54,7 +54,7 @@ module.exports = {
 		}
 		
 		// Unmonitor the server
-		removeServer.execute(interaction.guild, server);
+		await removeServer.execute(interaction.guild, server);
 
 		await sendMessage.newBasicMessage(interaction, 'The channels have been removed successfully.');
 	}

--- a/events/guildDelete.js
+++ b/events/guildDelete.js
@@ -2,6 +2,6 @@ module.exports = {
 	name: 'guildDelete',
 	once: false,
 	async execute(guild) {
-		serverDB.delete(guild.id);
+		await serverDB.delete(guild.id);
 	}
 };

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -4,7 +4,7 @@ module.exports = {
 	async execute(interaction, client) {
 		if (!interaction.isChatInputCommand()) return;
 
-		const command = client.commands.get(interaction.commandName);
+		const command = await client.commands.get(interaction.commandName);
 
 		if (!command) return;
 

--- a/functions/removeServer.js
+++ b/functions/removeServer.js
@@ -10,8 +10,8 @@ module.exports = {
 
 		// Remove server from database
 		let monitoredServers = (await serverDB.get(guild.id)) || [];
-		serverIndex = monitoredServers.indexOf(server);
-		monitoredServers.splice(serverIndex, 1);
+		serverIndex = await monitoredServers.indexOf(server);
+		await monitoredServers.splice(serverIndex, 1);
 		await serverDB.set(guild.id, monitoredServers);
 	}
 };


### PR DESCRIPTION
Added ability to refer to monitored servers with nicknames
-Added /nickname command to rename existing monitored servers
-Added nickname option to /monitor to give server a nickname upon monitoring it
-All other commands can now refer to monitored servers by both their nickname and IP address
Updated readme