### PR TITLE
disallow _ servers

### DIFF
--- a/commands/status.js
+++ b/commands/status.js
@@ -47,7 +47,7 @@ export async function execute(interaction) {
 		logWarning('Error pinging Minecraft server while running status command', {
 			'Guild ID': interaction.guildId,
 			'Server IP': server.ip,
-			Error: serverStatus.error || error
+			Error: error
 		});
 		await sendMessage(interaction, 'There was an error pinging the server. Please verify the server address, and try again in a few seconds!');
 		return;

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -38,7 +38,8 @@ export async function execute(interaction) {
 		});
 
 		await interaction.editReply({
-			content: 'There was an error while executing this command!',
+			content:
+				'There was an error while executing this command! Please try again in a few minutes. If the problem persists, please open an issue on GitHub.',
 			ephemeral: true
 		});
 	}

--- a/functions/getServerStatus.js
+++ b/functions/getServerStatus.js
@@ -1,10 +1,10 @@
 'use strict';
 import { statusBedrock, statusJava } from 'node-mcstatus';
 import unidecode from 'unidecode';
-import { isValidServer } from './inputValidation.js';
+import { validateHost } from './validateHost.js';
 
 export async function getServerStatus(server) {
-	if (!isValidServer(server.ip)) {
+	if (!validateHost(server.ip)) {
 		throw new Error('Invalid server IP');
 	}
 
@@ -16,7 +16,13 @@ export async function getServerStatus(server) {
 	let response = server.platform == 'bedrock' ? await statusBedrock(ip, port) : await statusJava(ip, port);
 	let latency = Date.now() - startTime + ' ms';
 
-	if (response.version) {
+	// Final check for valid response, incase our validation missed something
+	if (typeof response != 'object') {
+		throw new Error('Invalid server response');
+	}
+
+	// Use the clean name where possible
+	if (response.online) {
 		response.version.name = response.version.name_clean || response.version.name;
 	}
 

--- a/functions/updateServers.js
+++ b/functions/updateServers.js
@@ -35,7 +35,7 @@ export async function updateServers(client) {
 						logWarning('Error pinging Minecraft server while updating servers', {
 							'Server IP': server.ip,
 							'Guild ID': guild.id,
-							Error: serverStatus.error || error
+							Error: error
 						});
 						return;
 					}

--- a/functions/validateHost.js
+++ b/functions/validateHost.js
@@ -18,7 +18,7 @@ function validateAddress(ip) {
 	return (
 		isIP(decoded) ||
 		isFQDN(decoded, {
-			allow_underscores: true,
+			allow_underscores: false,
 			allow_numeric_tld: true
 		})
 	);


### PR DESCRIPTION
The current client status package that we use does not support underscores in the FQDN of the server name. This fix prevents you from checking the status of or monitoring a server with an _ in the FQDN (server address). We may undo this change if we find a workaround but this is not a guarantee. Please rename your servers to avoid underscores.